### PR TITLE
Minor bug fixes

### DIFF
--- a/Binning_program.py
+++ b/Binning_program.py
@@ -162,7 +162,6 @@ class ztf_object:
 			self.lc = pd.read_csv(self.loc, usecols = self.cols, comment='#')
 		except: #In case something goes wrong when reading in
 			self.text += f'Could not read in lc for {self.name}\n'+ traceback.format_exc() + '\n'
-			print(self.name)
 			self.peak_mjd = 0
 			self.lc = pd.DataFrame(columns=self.cols)
 			return


### PR DESCRIPTION
Of course, when you run a new program on a larger sample, all sorts of minor bugs that previously went unnoticed come crawling out. This upload fixes the ones I found when running the code on the entire ZTF18 sample. Hopefully most, if not all, have been caught by now.

Changes:
- Removed 2+4*(-2.5*np.log10(bins[((bins.binsize==binsize)&(bins.phase==phase))].Fratio)-21) condition from give_verdict. While this was originally implemented to remove some bins with weird detections, I suspect that the observations that caused them are now removed by the cuts, or something along those lines. As a result, this minimal nr. of points binned condition ended up mainly ignoring bins with 1 or 2 detections that were the end of the tail, where the individual observations were detections. This caused the tail fit procedure to not activate, and the remaining bins with detections being seen as interesting. Removing the condition fixes the tail fit & recognition if it is a normal decaying Ia tail.
- Fixed typo, there is always one somewhere, two in this case.
- Added handling for if there is no host data. In a rare case no host data was found. Now if this is the case, the object will simply not be removed from the sample, and it will be shown through a print statement.
- Updated mag, mag_err, upper_limit after baseline correction. When checking the bins in mag space, it helps when the correct data points are used. For this reason, not only the flux but also the  mag values & uncertainties need to be updated. Two conversion functions have been added for this.
- Fixed issue where upper limits could be chosen as peak mjd. A minor oversight from me, since the SN peak is when it is brightest, it is by definition a detection. In one case an (un)lucky set of upper limits with large uncertainties managed to snatch the title away from the true peak. This additional constraint is logical & should prevent this from happening in the future.
- Added handling for when there are few observations to consider for peak mjd. In a few cases, when there was only 1 point to consider in the first place, the while loop crashed before it can be broken out of.
- End of saved tail model goes up to 100 days after the last bin mjd. Mainly for aesthetic purposes, but also to show that those last bins were also part of the fit.