### PR TITLE
Operation mode unification

### DIFF
--- a/config.csv
+++ b/config.csv
@@ -1,3 +1,4 @@
+mode			'ZTFDR2'									#Input type (currently works with 'ZTFDR2', 'simulations' and 'fpbot')
 refmags_loc		'/home/jaccoterwel/Documents/Late-time_obs_binning/ref_im_data.csv'		#Location of the reference file magnitudes
 zp_rcid_loc		'/home/jaccoterwel/Documents/Late-time_obs_binning/zp_thresholds_quadID.txt'	#Location of the file with the zeropoints for each rcid
 loc_list_loc		'/home/jaccoterwel/Documents/Late-time_obs_binning/SN_host_locs.csv'		#Location of the file with the host galaxy locations
@@ -13,4 +14,4 @@ verdict_sigma		5										#sigma = flux/flux_err treshold for bin to be consider
 tail_fit_chi2dof_tresh	5										#Treshold for tail fit to be considered successful
 min_sep			0										#Minimal SN - host nucleus separation in arcsec
 min_successes		4										#Minimal nr. of successful attempts needed per object for late-time detection to be considered significant
-
+save_lc_and_bins	True										#Save uncorrected lc, baseline corrected lc (points used in the binning program), and bins

--- a/config.csv
+++ b/config.csv
@@ -1,10 +1,11 @@
-mode			'ZTFDR2'									#Input type (currently works with 'ZTFDR2', 'simulations' and 'fpbot')
-refmags_loc		'/home/jaccoterwel/Documents/Late-time_obs_binning/ref_im_data.csv'		#Location of the reference file magnitudes
-zp_rcid_loc		'/home/jaccoterwel/Documents/Late-time_obs_binning/zp_thresholds_quadID.txt'	#Location of the file with the zeropoints for each rcid
-loc_list_loc		'/home/jaccoterwel/Documents/Late-time_obs_binning/SN_host_locs.csv'		#Location of the file with the host galaxy locations
-dat_list_loc		'/home/jaccoterwel/Documents/Late-time_obs_binning/SN_host_data.csv'		#Lcoation of the file with the rest of the host galaxy data
+mode			ZTFDR2										#Input type (currently works with 'ZTFDR2', 'simulations' and 'fpbot')
+refmags_loc		/home/jaccoterwel/Documents/Late-time_obs_binning/ref_im_data.csv		#Location of the reference file magnitudes
+zp_rcid_loc		/home/jaccoterwel/Documents/Late-time_obs_binning/zp_thresholds_quadID.txt	#Location of the file with the zeropoints for each rcid
+loc_list_loc		/home/jaccoterwel/Documents/Late-time_obs_binning/SN_host_locs.csv		#Location of the file with the host galaxy locations
+dat_list_loc		/home/jaccoterwel/Documents/Late-time_obs_binning/SN_host_data.csv		#Lcoation of the file with the rest of the host galaxy data
+fields_list_loc		/home/jaccoterwel/Documents/simsurvey/ZTF_Fields.txt				#Location of the file with the field pointings
 late_time		100										#Nr. of days after found peak to start binning at
-cuts			[1,2,4,8,64]									#If any of these flags are raised, remove data point
+cuts			[1,2,4,8,64]									#If any of these flags are raised, remove data point (hardcoded for fpbot & simulations)
 base_gap		40										#Gap between end of baseline and found peak mjd in days
 binsizes		[100,75,50,25]									#Size in days of used bins
 phases			[0.0,0.25,0.5,0.75]								#Offsets of bins used for each binsize in fraction of size


### PR DESCRIPTION
Starting a new branch for this part of the effort to getting everything back up to date again. Up until now I had several versions intended to be used with different types of input (DR2-like csv, FPbot-like csv, simsurvey result).

The idea is to put everything into the same code, and choosing a 'mode'. Each one has its own instruction on how to generate the list of objects to be put through the pipeline, and its own load_source() function. In the load_source() function the object should be loaded and readied for the pipeline, which includes going to a more DR2-like format, as that is what the pipeline is expecting to receive.

At the moment the simsurvey lc is transformed into an FPbot-like input, but the step from FPbot-like to DR2-like has not been implemented yet. For this I need to go through the code that does this and add the relevant parts here (code received from MatSmithAstro).

After this the modes need to be tested before these branches can be merged of course, to make sure that they all work as intended.

One major advantage of this (as well as putting stuff in the config file) is that it should be relatively easy to adapt to a new input type / science case. For instance, it should be straight forward to specify a required baseline period instead of letting the pipeline determine this, or specify peak dates instead of finding them. All that is needed is to add a new mode with its own load_source() function.